### PR TITLE
Round tests

### DIFF
--- a/src/Round.js
+++ b/src/Round.js
@@ -1,0 +1,36 @@
+const Turn = require('../src/Turn');
+
+class Round {
+  constructor(deck) {
+    this.deck = deck;
+    this.turns = 0;
+    this.incorrectGuesses = [];
+  }
+
+  returnCurrentCard() {
+    return this.deck.allCards[this.turns];
+  }
+
+  takeTurn(guess) {
+    const currentCard = this.returnCurrentCard();
+    let turn = new Turn(guess, currentCard);
+    if (turn.evaluateGuess() === false) {
+      this.incorrectGuesses.push(turn.card.id);
+    }
+    this.turns += 1;
+    return turn.giveFeedback();
+  }
+
+  calculatePercentCorrect() {
+    const amountIncorrect = this.incorrectGuesses.length;
+    const amountCorrect = this.deck.allCards.length - amountIncorrect;
+    return Math.floor((amountCorrect / this.deck.allCards.length) * 100);
+  }
+
+  endRound() {
+    const percentCorrect = this.calculatePercentCorrect();
+    return `**Round over!** You answered ${percentCorrect}% of the questions correctly!`;
+  }
+};
+
+module.exports = Round;

--- a/src/Round.js
+++ b/src/Round.js
@@ -14,7 +14,7 @@ class Round {
   takeTurn(guess) {
     const currentCard = this.returnCurrentCard();
     let turn = new Turn(guess, currentCard);
-    if (turn.evaluateGuess() === false) {
+    if (!turn.evaluateGuess()) {
       this.incorrectGuesses.push(turn.card.id);
     }
     this.turns += 1;

--- a/src/Turn.js
+++ b/src/Turn.js
@@ -1,7 +1,7 @@
 class Turn {
   constructor(guess, card) {
     this.guess = guess;
-    this.currentCard = card;
+    this.card = card;
   }
 
   returnGuess() {
@@ -9,11 +9,11 @@ class Turn {
   }
 
   returnCard() {
-    return this.currentCard;
+    return this.card;
   }
 
   evaluateGuess() {
-    if (this.currentCard.correctAnswer === this.guess) {
+    if (this.card.correctAnswer === this.guess) {
       return true;
     } else {
       return false;

--- a/test/Round-test.js
+++ b/test/Round-test.js
@@ -25,76 +25,83 @@ describe('Round', () => {
     round = new Round(deck);
   });
 
-  it.skip('should be a function', () => {
+  it('should be a function', () => {
     expect(Round).to.be.a('function');
   });
 
-  it.skip('should be an instance of Round', () => {
+  it('should be an instance of Round', () => {
     expect(round).to.be.an.instanceOf(Round);
   });
 
-  it.skip('should take a deck as an argument', () => {
+  it('should take a deck as an argument', () => {
     expect(round.deck).to.deep.equal(deck);
   });
 
-  it.skip('should have turns set to 0 by default', () => {
+  it('should have turns set to 0 by default', () => {
     expect(round.turns).to.equal(0);
   });
 
-  // it('should create a new Turn when guess is made', () => {
-  //   round.takeTurn('pug');
-  //   expect(round.takeTurn()).to.equal();
-  // });
+  it('should have incorrect guesses set to empty by default', () => {
+    expect(round.incorrectGuesses).to.deep.equal([]);
+  });
 
-  it.skip('should give feedback based on accuracy of guess', () => {
+  it('should indicate which card is currently in play', () => {
+    round.returnCurrentCard();
+    expect(round.returnCurrentCard()).to.deep.equal(card1);
+  });
+
+  it('should increase number of turns when a turn is taken', () => {
+    expect(round.turns).to.equal(0);
+
     round.takeTurn('pug');
+    expect(round.turns).to.equal(1);
 
+    round.takeTurn('dog');
+    round.takeTurn('playing with bubble wrap');
+
+    expect(round.turns).to.equal(3);
+  });
+
+  it('should update current card with next card', () => {
+    round.takeTurn('pug');
+    expect(round.returnCurrentCard()).to.deep.equal(card2);
+
+    round.takeTurn('gallbladder');
+    expect(round.returnCurrentCard()).to.deep.equal(card3);
+  });
+
+  it('should store incorrect guesses', () => {
+    round.takeTurn('pug');
+    expect(round.incorrectGuesses).to.deep.equal([round.deck.allCards[0].id]);
+
+    round.takeTurn('log');
+    expect(round.incorrectGuesses).to.deep.equal([1, 14]);
+  });
+
+
+  it('should give feedback based on accuracy of guess', () => {
+    round.takeTurn('pug');
     expect(round.takeTurn()).to.equal('incorrect!');
   });
 
-  it.skip('should increase number of turns when a turn is taken', () => {
-    expect(round.turns).to.equal(0);
-
-    round.takeTurn(turn.guess);
-
-    expect(round.turns).to.equal(1);
-
-    round.takeTurn(turn.guess);
-
-    expect(round.turns).to.equal(2);
-  });
-
-  it.skip('should update current card with next card', () => {
+  it('should calculate the percentage of correct guesses', () => {
     round.takeTurn('pug');
+    round.takeTurn('gallbladder');
+    round.takeTurn('watching Netflix');
 
-    expect(turn.currentCard).to.deep.equal(card2);
-  });
-
-  it.skip('should store incorrect guesses', () => {
-    round.takeTurn('pug');
-
-    expect(round.incorrectGuesses).to.deep.equal(round.deck.allCards[1].id);
-  });
-
-  it.skip('should indicate which card is currently in play', () => {
-    round.returnCurrentCard();
-
-    expect(round.returnCurrentCard()).to.deep.equal(turn.currentCard);
-  });
-
-  it.skip('should calculate the percentage of correct guesses', () => {
     round.calculatePercentCorrect();
 
-    expect(round.calculatePercentCorrect()).to.equal('0%');
+    expect(round.calculatePercentCorrect()).to.equal(33);
   });
 
-  it.skip('should show termination message', () => {
+  it('should show termination message', () => {
+    round.takeTurn('pug');
+    round.takeTurn('gallbladder');
+    round.takeTurn('watching Netflix');
+
+    round.calculatePercentCorrect();
     round.endRound();
 
-    expect(round.endRound()).to.equal('Round over! You answered 0% of the questions correctly!');
-  });
-
-  it.skip('should have incorrect guesses set to empty by default', () => {
-    expect(round.incorrectGuesses).to.deep.equal([]);
+    expect(round.endRound()).to.equal('**Round over!** You answered 33% of the questions correctly!');
   });
 });

--- a/test/Round-test.js
+++ b/test/Round-test.js
@@ -1,0 +1,100 @@
+const chai = require('chai');
+const expect = chai.expect;
+
+const Card = require('../src/Card');
+const Turn = require('../src/Turn');
+const Deck = require('../src/Deck');
+const Round = require('../src/Round');
+
+describe('Round', () => {
+  let card1;
+  let card2;
+  let card3;
+  let emptyDeck;
+  let deck;
+  let turn;
+  let round;
+
+  beforeEach(() => {
+    card1 = new Card(1, 'What is Robbie\'s favorite animal', ['sea otter', 'pug', 'capybara'], 'sea otter');
+    card2 = new Card(14, 'What organ is Khalid missing?', ['spleen', 'appendix', 'gallbladder'], 'gallbladder');
+    card3 = new Card(12, 'What is Travis\'s favorite stress reliever?', ['listening to music', 'watching Netflix', 'playing with bubble wrap'], 'playing with bubble wrap');
+    emptyDeck = new Deck([]);
+    deck = new Deck([card1, card2, card3]);
+    turn = new Turn('pug', card1);
+    round = new Round(deck);
+  });
+
+  it.skip('should be a function', () => {
+    expect(Round).to.be.a('function');
+  });
+
+  it.skip('should be an instance of Round', () => {
+    expect(round).to.be.an.instanceOf(Round);
+  });
+
+  it.skip('should take a deck as an argument', () => {
+    expect(round.deck).to.deep.equal(deck);
+  });
+
+  it.skip('should have turns set to 0 by default', () => {
+    expect(round.turns).to.equal(0);
+  });
+
+  // it('should create a new Turn when guess is made', () => {
+  //   round.takeTurn('pug');
+  //   expect(round.takeTurn()).to.equal();
+  // });
+
+  it.skip('should give feedback based on accuracy of guess', () => {
+    round.takeTurn('pug');
+
+    expect(round.takeTurn()).to.equal('incorrect!');
+  });
+
+  it.skip('should increase number of turns when a turn is taken', () => {
+    expect(round.turns).to.equal(0);
+
+    round.takeTurn(turn.guess);
+
+    expect(round.turns).to.equal(1);
+
+    round.takeTurn(turn.guess);
+
+    expect(round.turns).to.equal(2);
+  });
+
+  it.skip('should update current card with next card', () => {
+    round.takeTurn('pug');
+
+    expect(turn.currentCard).to.deep.equal(card2);
+  });
+
+  it.skip('should store incorrect guesses', () => {
+    round.takeTurn('pug');
+
+    expect(round.incorrectGuesses).to.deep.equal(round.deck.allCards[1].id);
+  });
+
+  it.skip('should indicate which card is currently in play', () => {
+    round.returnCurrentCard();
+
+    expect(round.returnCurrentCard()).to.deep.equal(turn.currentCard);
+  });
+
+  it.skip('should calculate the percentage of correct guesses', () => {
+    round.calculatePercentCorrect();
+
+    expect(round.calculatePercentCorrect()).to.equal('0%');
+  });
+
+  it.skip('should show termination message', () => {
+    round.endRound();
+
+    expect(round.endRound()).to.equal('Round over! You answered 0% of the questions correctly!');
+  });
+
+  it.skip('should have incorrect guesses set to empty by default', () => {
+    expect(round.incorrectGuesses).to.deep.equal([]);
+  });
+});

--- a/test/Turn-test.js
+++ b/test/Turn-test.js
@@ -36,7 +36,7 @@ describe('Turn', function() {
     const card = new Card(1, 'What allows you to define a set of related information using key-value pairs?', ['object', 'array', 'function'], 'object');
     const turn = new Turn('function', card);
 
-    expect(turn.currentCard).to.deep.equal(card);
+    expect(turn.card).to.deep.equal(card);
   });
 
   it('should return the guess', function() {


### PR DESCRIPTION
### Type of change made:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling- no new features

### Detailed Description

This PR creates and updates `Round.js` and `Round-test.js`, so that all required functionality is accounted for in the test suite.  Default properties and property updates are also tested.  This PR changes the `currentCard` on Turn to `card` for readability purposes, in both the implementation and test files.

### Why is this change required? What problem does it solve?

The changes made for the Turn class helped to clear up some confusion on my end.  I was misunderstanding the responsibilities of the Turn object, and had misinterpreted that the current card should be tracked on that object.  I changed it to `card` because the Round class's methods use the language of `currentCard`.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

I struggled to make `returnCurrentCard` dynamic.  At first, I hard coded the index of 0 being accessed in the deck.  In order for the current card to be anything other than the first card in the deck, I needed a way to update the value of the current card based on another property.  I noticed that `round.turns` was going to be incremented by 1 in `round.takeTurn()`, and that the number of turns will always be equal to the index of the next card in the deck.  So, I use `round.turns` with bracket notation to get that index number of the card.

### Files modified:
- [x] Round.js
- [x] Turn.js
- [x] Round-test.js
- [x] Turn-test.js